### PR TITLE
Zombies comeback.

### DIFF
--- a/src/model/simulate.jl
+++ b/src/model/simulate.jl
@@ -244,7 +244,7 @@ function ExtinctionCallback(extinction_threshold, verbose::Bool)
         new_extinct_sp_dict = Dict(sp => t for sp in new_extinct_sp)
         merge!(integrator.p.extinct_sp, new_extinct_sp_dict) # update extinct species list
         # Info message (printed only if verbose = true).
-        if verbose
+        if verbose && !isempty(new_extinct_sp)
             S, S_ext = length(integrator.u), length(all_extinct_sp)
             @info "Species $([new_extinct_sp...]) went extinct at time t = $t. \n" *
                   "$S_ext out of $S species are extinct."

--- a/test/model/test-zombies.jl
+++ b/test/model/test-zombies.jl
@@ -1,0 +1,52 @@
+# Test inspired by this issue:
+# https://discourse.julialang.org/t/zombies-in-biological-ode-why-is-my-solver-not-sticking-to-zero/90409
+@testset "No zombies, extinction are handled correctly." begin
+    foodweb = FoodWeb([0 0 0; 1 0 0; 1 0 0])
+    biorates = BioRates(foodweb; y = [0, 7.992, 8])
+    params = ModelParameters(foodweb; biorates = biorates)
+    B0 = [0.5, 0.5, 0.5]
+    sol = simulates(
+        params,
+        B0;
+        callback = ExtinctionCallback(1e-5, true),
+        tmax = 300_000,
+        verbose = false,
+        compare_rtol = 1e-6,
+    )
+    @test keys(get_extinct_species(sol)) == Set([2])
+    sol2 = sol[2, :] # trajectory of species 2 biomass
+    idx_cb_triggered = findall(x -> 0 < x < 1e-5, sol2)
+    @test length(idx_cb_triggered) == 1 # cb triggered only once (no zombies)
+    idx_cb_triggered = idx_cb_triggered[1]
+    # When callback is triggered previous and next state are saved
+    # to identify unambiguously the discontinuity.
+    # Then we have two time steps at t_discontinuity:
+    # 1. 0 < B_going_extinct <= extinction_threshold (before the callback)
+    # 2. B_going_extinct = 0 (after the callback)
+    @test sol.t[idx_cb_triggered] == sol.t[idx_cb_triggered+1]
+    @test all(sol2 .>= 0) # no anti-biomass
+end
+
+# Ensure that when an species already extinct species comeback to life (aka a zombie)
+# when using an implicit solver, that no @info message are shown.
+# For more information about zombies see these issues:
+# https://github.com/BecksLab/EcologicalNetworksDynamics.jl/issues/65
+# https://discourse.julialang.org/t/zombies-in-biological-ode-why-is-my-solver-not-sticking-to-zero/90409
+@testset "Do not print zombies." begin
+    Random.seed!(12) # Set a seed for reproducibility.
+    S = 30
+    fw = FoodWeb(nichemodel, S; C = 0.1)
+    functional_response = ClassicResponse(fw)
+    params = ModelParameters(fw; functional_response)
+    logger = TestLogger()
+    with_logger(logger) do
+        simulates(params, rand(S); tmax = 1_000_000, verbose = true)
+    end
+    # Test that the `simulate` @info messages never contain empty vector of new extinct
+    # species.
+    # Otherwise, this means that a zombies has appeared and triggered the @info message.
+    @test length(logger.logs) > 0
+    for log in logger.logs
+        log.level == Logging.Info && @test !(occursin("[]", log.message))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using SparseArrays
 using Random
 using JuliaFormatter
 using SyntaxTree
-using Logging #  TODO: remove once warnings are removed from `generate_dbdt`.
+using Logging
 using Statistics
 
 
@@ -41,6 +41,7 @@ test_files = [
     "model/test-model_parameters.jl",
     "model/test-consumption.jl",
     "model/test-simulate.jl",
+    "model/test-zombies.jl",
     "model/test-set_temperature.jl",
     "measures/test-functioning.jl",
     "measures/test-stability.jl",


### PR DESCRIPTION
On a stormy night, I discovered to my horror that the zombies had reappeared.
From my investigation, it seems that their resurrection was due to the use of the `reltol` kwarg of `solve`. Hopefully, the issue seems to be only visual. Indeed, Zombies abundances are well contained (see [this](https://discourse.julialang.org/t/zombies-in-biological-ode-why-is-my-solver-not-sticking-to-zero/90409/23?)), however the `@info` message from the extinction callback is still triggered.
Then, I fixed this by ensuring that the `@info` extinction message is printed only when when the vector of new extinct species was not empty, *i.e.* the species that triggered the callback was not a zombie.

## Minimal Working Example

```julia
using EcologicalNetworksDynamics
using Random

seed = 12
Random.seed!(seed)
@info seed

S = 30
fw = FoodWeb(nichemodel, S; C = 0.1)
functional_response = ClassicResponse(fw)
p = ModelParameters(fw; functional_response)
sol = simulate(p, rand(S); tmax = 1_000_000, reltol = 1e-9)
```

## What could be done next

Set the default solver to an explicit solver that immunize us against zombies (*e.g.* Range Kunta 4 `RK4`, #122 👀), and throw a warning to the user when they plays with fire and uses an implicit algorithm. For more information, about the DifferentialEquations solvers see [this](https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/).