### PR TITLE
Englishing docstrings ✏️

### DIFF
--- a/src/measures/functioning.jl
+++ b/src/measures/functioning.jl
@@ -13,10 +13,10 @@ over the `last` timesteps. `kwargs...` are optional arguments passed to
 
   - `solution`: output of `simulate()` or `solve()`
   - `threshold`: biomass threshold below which a species is considered extinct. Set to 0 by
-    debault and it is recommended to let as this. It is recommended to change the threshold
+    default and it is recommended to leave as this. It is recommended to change the threshold
     using [`ExtinctionCallback`](@ref) in [`simulate`](@ref).
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> foodweb = FoodWeb([0 0; 1 0]);
@@ -48,9 +48,9 @@ end
 """
     richness(n::AbstractVector; threshold = 0)
 
-When applied to a vector of biomass, returns the number of biomass above `threshold`
+When applied to a vector of biomass, returns the number of biomasses above `threshold`
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> richness([0, 1])
@@ -65,7 +65,7 @@ richness(n::AbstractVector; threshold = 0) = sum(n .> threshold)
 """
     species_persistence(solution; kwargs...)
 
-Returns the average proportion of species having a biomass superior or equal to threshold
+Returns the average proportion of species having a biomass greater than or equal to threshold
 over the `last` timesteps.
 
 `kwargs...` arguments are forwarded to [`extract_last_timesteps`](@ref). See
@@ -75,7 +75,7 @@ When applied to a vector of biomass, e.g.
 `species_persistence(n::Vector; threshold = 0)`, it returns the proportion of
 species which biomass is above `threshold`.
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> foodweb = FoodWeb([0 0; 0 0]; quiet = true);
@@ -111,7 +111,7 @@ species_persistence(n::AbstractVector; threshold = 0) = richness(n; threshold) /
 
 Returns a named tuple of total and species biomass, averaged over the `last` timesteps.
 
-# Arguments
+# Arguments:
 
 `kwargs...` arguments are forwarded to [`extract_last_timesteps`](@ref). See
 [`extract_last_timesteps`](@ref) for the argument details.
@@ -119,7 +119,7 @@ Returns a named tuple of total and species biomass, averaged over the `last` tim
 Can also handle a species x time biomass matrix, e.g. `biomass(mat::AbstractMatrix;)` or a
 vector, e.g. `biomass(vec::AbstractVector;)`.
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> foodweb = FoodWeb([0 0; 1 0]);
@@ -160,7 +160,7 @@ over the `last` timesteps.
 
 Can also handle a vector, e.g. shannon_diversity(n::AbstractVector; threshold = 0)
 
-# Reference
+# Reference:
 
 https://en.wikipedia.org/wiki/Diversity_index#Shannon_index
 """
@@ -194,7 +194,7 @@ over the `last` timesteps.
 
 Can also handle a vector, e.g. simpson(n::AbstractVector; threshold = 0)
 
-# Reference
+# Reference:
 
 https://en.wikipedia.org/wiki/Diversity_index#Simpson_index
 """
@@ -219,14 +219,14 @@ end
 """
     evenness(solution; threshold = 0, kwargs...)
 
-Computes the average Pielou evenness, over the `last` timesteps.
+Computes the average Pielou evenness over the `last` timesteps.
 
 `kwargs...` arguments are forwarded to [`extract_last_timesteps`](@ref). See
 [`extract_last_timesteps`](@ref) for the argument details.
 
 Can also handle a vector, e.g. `evenness(n::AbstractVector; threshold = 0)`
 
-# Reference
+# Reference:
 
 https://en.wikipedia.org/wiki/Species_evenness
 """
@@ -250,13 +250,13 @@ end
     producer_growth(solution; kwargs...)
 
 Returns the average growth rates of producers over the `last` timesteps as as well as the
-average (`mean`) and the standard deviation (`std`). It also returns  by all the growth
+average (`mean`) and the standard deviation (`std`). It also returns all the growth
 rates (`all`) as a species x timestep matrix (as the solution matrix).
 
 kwargs... arguments are forwarded to [`extract_last_timesteps`](@ref). See
 [`extract_last_timesteps`](@ref) for the argument details.
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> foodweb = FoodWeb([0 1 1; 0 0 0; 0 0 0]);
@@ -332,13 +332,13 @@ get_parameters(sol) = sol.prob.p.params
     trophic_structure(solution; threshold = 0, idxs = nothing, kwargs...)
 
 Returns the maximum, mean and weighted mean trophic level averaged over the `last`
-timesteps. It also returns the adjacency matrix containing only the living species and the
-vector of the living species at the last timestep.
+timesteps. It also returns the adjacency matrix containing only the living species and a
+vector of the living species' identities at the last timestep.
 
 kwargs... arguments are forwarded to [`extract_last_timesteps`](@ref). See
 [`extract_last_timesteps`](@ref) for the argument details.
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> foodweb = FoodWeb([0 0 0; 0 0 0; 1 1 0]);
@@ -447,7 +447,7 @@ kwargs... arguments are forwarded to [`extract_last_timesteps`](@ref). See
 These functions also handle biomass vectors associated with a network, as well as
 a vector of trophic levels (See examples).
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> A = [0 0; 1 0];
@@ -565,15 +565,15 @@ end
 """
     living_species(solution::Solution; threshold = 0, idxs = nothing, kwargs...)
 
-Returns the vectors of alive species and their indices in the original network.
-Living species are the ones having, in average, a biomass above `threshold` over
+Returns vectors of living species names and their indices within the original network.
+Living species are those with an average biomass above `threshold` over
 the `last` timesteps. `kwargs...` are optional arguments passed to
 [`extract_last_timesteps`](@ref).
 
 `kwargs...` arguments are forwarded to [`extract_last_timesteps`](@ref). See
 [`extract_last_timesteps`](@ref) for the argument details.
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> foodweb = FoodWeb([0 1 1; 0 0 0; 0 0 0]);
@@ -616,7 +616,7 @@ timesteps.
 `kwargs...` arguments are forwarded to [`extract_last_timesteps`](@ref). See
 [`extract_last_timesteps`](@ref) for the argument details.
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> foodweb = FoodWeb([0 0; 1 0]);

--- a/src/measures/stability.jl
+++ b/src/measures/stability.jl
@@ -5,7 +5,7 @@ Various measures of stability.
 """
     species_cv(solution::Solution; threshold = 0, last = "10%", kwargs...)
 
-Computes the temporal coefficient of variation of species biomass and its average.
+Computes the temporal coefficient of variation of species biomass and calculates the mean.
 
 See [`coefficient_of_variation`](@ref) for the details.
 """
@@ -52,7 +52,7 @@ Loreau & de Mazancourt (2008).
 
 See [`coefficient_of_variation`](@ref) for the argument details.
 
-# Reference
+# Reference:
 
 Loreau, M., & de Mazancourt, C. (2008). Species Synchrony and Its Drivers :
 Neutral and Nonneutral Community Dynamics in Fluctuating Environments. The
@@ -151,13 +151,13 @@ unbiaised estimator of the variance.
 
 See [`richness`](@ref) for the argument details.
 
-# Reference
+# Reference:
 
 Thibaut, L. M., & Connolly, S. R. (2013). Understanding diversity–stability
 relationships : Towards a unified model of portfolio effects. Ecology Letters,
 16(2), 140‑150. https://doi.org/10.1111/ele.12019
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> foodweb = FoodWeb([0 1 1; 0 0 0; 0 0 0]); # Two producers and one consumer

--- a/src/measures/structure.jl
+++ b/src/measures/structure.jl
@@ -7,7 +7,7 @@ richness(net::EcologicalNetwork) = richness(get_trophic_adjacency(net))
 richness(A::AbstractMatrix) = size(A, 1)
 
 """
-Connectance of network: number of links / (number of species)^2
+Connectance of network: number of links / (number of species)²
 """
 connectance(A::AbstractMatrix) = sum(A) / richness(A)^2
 connectance(foodweb::FoodWeb) = connectance(foodweb.A)
@@ -34,7 +34,7 @@ isproducer(i, net::FoodWeb) = isproducer(i, net.A)
 isproducer(i, net::MultiplexNetwork) = isproducer(i, net.layers[:trophic].A)
 
 """
-Return indexes of the producers of the given `network`.
+Return indices of the producers of the given `network`.
 """
 producers(net) = filter(isproducer, net)
 producers(A::AbstractMatrix) = (1:richness(A))[all(A .== 0; dims = 2)|>vec]
@@ -44,9 +44,9 @@ producers(A::AbstractMatrix) = (1:richness(A))[all(A .== 0; dims = 2)|>vec]
 """
     predators_of(i, network)
 
-Return indexes of the predators of species `i` for the given `network`.
+Return indices of the predators of species `i` for the given `network`.
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> foodweb = FoodWeb([0 0 0; 1 0 0; 1 1 0]);
@@ -78,7 +78,7 @@ ispredator(i, net::FoodWeb) = ispredator(i, net.A)
 ispredator(i, net::MultiplexNetwork) = ispredator(i, net.layers[:trophic].A)
 
 """
-Return indexes of the predators of the given `network`.
+Return indices of the predators of the given `network`.
 """
 predators(net::EcologicalNetwork) = filter(ispredator, net)
 #### end ####
@@ -87,9 +87,9 @@ predators(net::EcologicalNetwork) = filter(ispredator, net)
 """
     preys_of(i, network)
 
-Return indexes of the preys of species `i` for the given `network`.
+Return indices of the preys of species `i` for the given `network`.
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> foodweb = FoodWeb([0 0 0; 0 0 0; 1 1 0]);
@@ -117,7 +117,7 @@ isprey(i, net::FoodWeb) = isprey(i, net.A)
 isprey(i, net::MultiplexNetwork) = isprey(i, net.layers[:trophic].A)
 
 """
-Return indexes of the preys of the network (`net`).
+Return indices of the preys of the network (`net`).
 """
 preys(net::EcologicalNetwork) = filter(isprey, net)
 preys(A::AbstractSparseMatrix) = [i for i in 1:size(A, 1) if !isempty(A[:, i].nzval)]
@@ -269,7 +269,7 @@ trophic_classes() = (:producers, :intermediate_consumers, :top_predators)
 
 Remove a list of species from a `FoodWeb`, a `MultiplexNetwork` or an adjacency matrix.
 
-# Examples
+# Examples:
 
 Adjacency matrix.
 

--- a/src/measures/utils.jl
+++ b/src/measures/utils.jl
@@ -7,7 +7,7 @@ Utility functions for functions in measures
 
 Returns the biomass matrix of species x time over the `last` timesteps.
 
-# Arguments
+# Arguments:
 
   - `last`: the number of last timesteps to consider. A percentage can also be also be
     provided as a `String` ending by `%`. Defaulted to 1.
@@ -17,7 +17,7 @@ Returns the biomass matrix of species x time over the `last` timesteps.
 See [`richness`](@ref) for the other arguments. If `idxs` is an integer,
 it returns a vector of the species biomass instead of a matrix.
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> fw = FoodWeb([0 0; 1 0]);
@@ -179,7 +179,7 @@ end
 
 Returns a tuple with species having a biomass above `threshold` at the end of a simulation.
 
-# Examples
+# Examples:
 
 ```jldoctest
 julia> foodweb = FoodWeb([0 0; 0 0]; quiet = true);


### PR DESCRIPTION
I've finally had a read of the docstrings @alaindanet wrote for the simulation output utils and made a few minor changes.

There are 4 things that I think are worth discussing rather than me just changing them:

1) Within the `richness` docstring (line 15) within `functioning.jl` we have:

>   - `threshold`: biomass threshold below which a species is considered extinct. Set to 0 by
    default and it is recommended to leave as this. It is recommended to change the threshold
    using [`ExtinctionCallback`](@ref) in [`simulate`](@ref).

Which reads as both we should leave the threshold and change it... I'm not sure what information the second sentence is meant to be providing so I don't know how to change it

2) There are some inconsistences with `solution::Solution` vs `solution` when writing function arguments - for example:
`function richness(solution::Solution;` vs `function species_persistence(solution;`

Is there a purpose to this or should this be tidied up to always `solution::Solution`?

3) Line 435 within `functioning.jl` reads `docstring = """`. Everywhere else this is `"""`

I have left this because I have assumed this is deliberate and beyond my knowledge, but just wanted to check this was meant to be there?

4) Maybe you've had this discussion in the hundreds of comments on the original pull request but have we considered replacing instances of "alive" and "living" within function names with "extant"?


